### PR TITLE
Some cleanup and nicer labels

### DIFF
--- a/.ipynb_checkpoints/Comparative static LCA in Brightway2-checkpoint.ipynb
+++ b/.ipynb_checkpoints/Comparative static LCA in Brightway2-checkpoint.ipynb
@@ -50,17 +50,17 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Biosphere database already present!!! No setup is needed\n"
-     ]
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
       "Warning: bad escape \\s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Biosphere database already present!!! No setup is needed\n"
      ]
     }
    ],
@@ -153,6 +153,31 @@
      "output_type": "stream",
      "text": [
       "This database is already searchable\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: _[traitname]_default handlers are deprecated: use default decorator instead\n",
+      "Warning: _[traitname]_changed handlers are deprecated: use observe and unobserve instead\n",
+      "Warning: _[traitname]_default handlers are deprecated: use default decorator instead\n",
+      "Warning: _[traitname]_default handlers are deprecated: use default decorator instead\n",
+      "Warning: _[traitname]_default handlers are deprecated: use default decorator instead\n",
+      "Warning: _[traitname]_default handlers are deprecated: use default decorator instead\n",
+      "Warning: _[traitname]_changed handlers are deprecated: use observe and unobserve instead\n",
+      "Warning: _[traitname]_changed handlers are deprecated: use observe and unobserve instead\n",
+      "Warning: _[traitname]_changed handlers are deprecated: use observe and unobserve instead\n",
+      "Warning: _[traitname]_changed handlers are deprecated: use observe and unobserve instead\n",
+      "Warning: _[traitname]_changed handlers are deprecated: use observe and unobserve instead\n",
+      "Warning: _[traitname]_changed handlers are deprecated: use observe and unobserve instead\n",
+      "Warning: _[traitname]_changed handlers are deprecated: use observe and unobserve instead\n",
+      "Warning: _[traitname]_changed handlers are deprecated: use observe and unobserve instead\n",
+      "Warning: _[traitname]_changed handlers are deprecated: use observe and unobserve instead\n",
+      "Warning: _[traitname]_changed handlers are deprecated: use observe and unobserve instead\n",
+      "Warning: _[traitname]_default handlers are deprecated: use default decorator instead\n",
+      "Warning: _[traitname]_default handlers are deprecated: use default decorator instead\n",
+      "Warning: _[traitname]_default handlers are deprecated: use default decorator instead\n"
      ]
     },
     {


### PR DESCRIPTION
- Use and instead of if.. if…
- Label columns and cleanup names in data frame
- Iterate over `methods`
- Don’t need {0}, {1} if arguments in correct order